### PR TITLE
fix(windows): restore agent-server stdio for Issue #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- 修复 Windows wrapper 未显式绑定父进程 stdin/stdout/stderr 导致 agent-server JSON-RPC 通道失联的问题；补充 Windows 多帧通信、stderr 隔离和退出码测试。
+
 ## [0.2.0] - 2026-08-31
 
 - **system-role.md 重写为角色扮演式交付人格：** 从 831 行 (~31KB) 压缩到 141 行 (~9.8KB)。

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -17,7 +17,7 @@ ZCODE_AGENT_SERVER_COMMAND
 ZCODE_AGENT_SERVER_ARGS_JSON
 ```
 
-macOS 安装器把 `ZCODE_AGENT_SERVER_COMMAND` 指向 `~/.zcode-keysmith/bin/zcode-agent-wrapper.py`。Windows 安装器把 command 指向当前 Python 解释器，并把 wrapper 路径作为第一个参数，避开 Windows 不能可靠直接执行 `.py` 文件的问题。wrapper 读取 ZCode 自带 runtime（macOS 默认 `/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs`；Windows 为安装目录下 `resources/glm/zcode.cjs`），在用户目录缓存一份副本，只替换一处 `customSystemPrompt` 入口，使其优先读取 `~/.zcode-keysmith/system-role.md`，再用 ZCode 自带 Electron node 启动缓存 runtime。macOS 优先使用 Helper 可执行文件，Windows 使用 `ZCode.exe` 并仅为 agent-server 子进程设置 `ELECTRON_RUN_AS_NODE=1`。
+macOS 安装器把 `ZCODE_AGENT_SERVER_COMMAND` 指向 `~/.zcode-keysmith/bin/zcode-agent-wrapper.py`。Windows 安装器把 command 指向当前 Python 解释器，并把 wrapper 路径作为第一个参数，避开 Windows 不能可靠直接执行 `.py` 文件的问题。wrapper 读取 ZCode 自带 runtime（macOS 默认 `/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs`；Windows 为安装目录下 `resources/glm/zcode.cjs`），在用户目录缓存一份副本，只替换一处 `customSystemPrompt` 入口，使其读取 `~/.zcode-keysmith/system-role.md`，再用 ZCode 自带 Electron node 启动缓存 runtime。Windows wrapper 会显式把父进程的 stdin/stdout/stderr OS 句柄绑定给 agent-server 子进程，并保留 stderr 与 stdout 的分离，保持长连接 JSON-RPC 通信；仅传递这三个句柄，不泄漏其他句柄。macOS 优先使用 Helper 可执行文件，Windows 使用 `ZCode.exe` 并仅为 agent-server 子进程设置 `ELECTRON_RUN_AS_NODE=1`。
 
 ZCode runtime 会把 `customSystemPrompt` 放进 `injectionTarget: "system"` 的上下文段，因此这份文件走的是 system message 路径，不是项目说明文件。若源文件来自 GLM ChatML 导出，外层 `<|im_start|>system:` / `<|im_end|>` 会在写入前被清理。
 
@@ -139,7 +139,7 @@ ZCODE_AGENT_SERVER_COMMAND
 ZCODE_AGENT_SERVER_ARGS_JSON
 ```
 
-On macOS, the installer points `ZCODE_AGENT_SERVER_COMMAND` at `~/.zcode-keysmith/bin/zcode-agent-wrapper.py`. On Windows, the command is the current Python interpreter and the wrapper path is the first argument, avoiding unreliable direct `.py` execution. The wrapper reads the bundled ZCode runtime (`/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs` on macOS or `resources/glm/zcode.cjs` under the Windows install), caches a copy, patches only the `customSystemPrompt` entrypoint, and launches it with ZCode's Electron Node. Windows sets `ELECTRON_RUN_AS_NODE=1` only for the agent-server child process.
+On macOS, the installer points `ZCODE_AGENT_SERVER_COMMAND` at `~/.zcode-keysmith/bin/zcode-agent-wrapper.py`. On Windows, the command is the current Python interpreter and the wrapper path is the first argument, avoiding unreliable direct `.py` execution. The wrapper reads the bundled ZCode runtime (`/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs` on macOS or `resources/glm/zcode.cjs` under the Windows install), caches a copy, patches only the `customSystemPrompt` entrypoint, and launches it with ZCode's Electron Node. On Windows it explicitly binds the parent's stdin/stdout/stderr OS handles to the agent-server child, keeps stderr separate from stdout, and passes only those three handles so long-lived JSON-RPC stays connected. Windows sets `ELECTRON_RUN_AS_NODE=1` only for the agent-server child process.
 
 The runtime places `customSystemPrompt` into a context segment with `injectionTarget: "system"`, so the file enters the system-message path rather than a project instruction file. GLM ChatML wrappers (`<|im_start|>system:` / `<|im_end|>`) are stripped before write.
 

--- a/tests/test_zcode_keysmith.py
+++ b/tests/test_zcode_keysmith.py
@@ -197,9 +197,18 @@ def test_rendered_wrapper_is_valid_python_and_uses_configured_cache_dir(tmp_path
     assert json.dumps(str(paths.cache_dir), ensure_ascii=False) in wrapper_text
     assert 'if os.name == "nt":' in wrapper_text
     assert "acquire_cache_lock" in wrapper_text
-    assert "subprocess.Popen" in wrapper_text
+    assert "def _stdio_stream" in wrapper_text
+    assert "def _spawn_windows_node" in wrapper_text
+    assert '"stdin": _stdio_stream(sys.stdin)' in wrapper_text
+    assert '"stdout": _stdio_stream(sys.stdout)' in wrapper_text
+    assert '"stderr": _stdio_stream(sys.stderr)' in wrapper_text
+    assert "subprocess.PIPE" not in wrapper_text
+    assert "threading" not in wrapper_text
+    assert "close_fds=True" in wrapper_text
+    assert "fileno()" in wrapper_text
+    assert 'RuntimeError("Windows %s stream is not available: %s"' in wrapper_text
     assert "proc.wait()" in wrapper_text
-    # Popen inherits stdin/stdout/stderr directly for stable JSON-RPC communication
+    # Windows binds the parent's OS handles explicitly.
     assert "env=env" in wrapper_text
 
 
@@ -243,9 +252,11 @@ def test_windows_wrapper_inherits_stdio_and_propagates_exit_code(tmp_path):
     runtime.write_text(
         "MARKER = '''customSystemPrompt:this.config.systemPrompt,language:'''\n"
         "import sys\n"
-        "payload = sys.stdin.buffer.read()\n"
-        "sys.stdout.buffer.write(payload.upper())\n"
-        "sys.stdout.buffer.flush()\n"
+        "for line in sys.stdin.buffer:\n"
+        "    sys.stderr.buffer.write(b'diagnostic\\n')\n"
+        "    sys.stderr.buffer.flush()\n"
+        "    sys.stdout.buffer.write(line.upper())\n"
+        "    sys.stdout.buffer.flush()\n"
         "raise SystemExit(23)\n",
         encoding="utf-8",
     )
@@ -262,7 +273,7 @@ def test_windows_wrapper_inherits_stdio_and_propagates_exit_code(tmp_path):
     }
     completed = subprocess.run(
         [sys.executable, str(paths.wrapper), "app-server", "--stdio"],
-        input=b"json-rpc-stdio",
+        input=b"json-rpc-one\njson-rpc-two\n",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         check=False,
@@ -270,8 +281,8 @@ def test_windows_wrapper_inherits_stdio_and_propagates_exit_code(tmp_path):
     )
 
     assert completed.returncode == 23
-    assert completed.stdout == b"JSON-RPC-STDIO"
-    assert completed.stderr == b""
+    assert completed.stdout == b"JSON-RPC-ONE\nJSON-RPC-TWO\n"
+    assert completed.stderr == b"diagnostic\ndiagnostic\n"
 
 
 def test_doctor_reports_state_without_secret_values(tmp_path, capsys, monkeypatch):

--- a/zcode-keysmith.py
+++ b/zcode-keysmith.py
@@ -697,6 +697,27 @@ LOG_DIR = pathlib.Path(os.environ.get("ZCODE_KEYSMITH_LOG_DIR") or {log_dir_json
 LOG_FILE = LOG_DIR / "wrapper-start.jsonl"
 
 
+def _stdio_stream(stream):
+    """Return the binary OS stream so Windows binds the parent's pipes."""
+    return getattr(stream, "buffer", stream)
+
+
+def _spawn_windows_node(command, env):
+    streams = {{
+        "stdin": _stdio_stream(sys.stdin),
+        "stdout": _stdio_stream(sys.stdout),
+        "stderr": _stdio_stream(sys.stderr),
+    }}
+    for name, stream in streams.items():
+        try:
+            stream.fileno()
+        except (AttributeError, OSError, ValueError) as exc:
+            raise RuntimeError("Windows %s stream is not available: %s" % (name, exc)) from exc
+    # Keep Python's precise Windows handle-list inheritance while binding only
+    # the three streams needed by the long-lived JSON-RPC child.
+    return subprocess.Popen(command, env=env, close_fds=True, **streams)
+
+
 def _frozen_self_dispatch() -> bool:
     # Windows points the agent-server command at the frozen CLI executable.
     # Re-enter the generated wrapper in-process instead of treating its path
@@ -817,11 +838,9 @@ def main() -> int:
     env = os.environ.copy()
     env["ELECTRON_RUN_AS_NODE"] = "1"
     if os.name == "nt":
-        # Use Popen to inherit stdin/stdout/stderr directly for stable long-running JSON-RPC communication
-        proc = subprocess.Popen(
-            [NODE_COMMAND, str(runtime), *args],
-            env=env,
-        )
+        # Bind all three parent OS handles explicitly. Python 3.14 otherwise
+        # starts the child without Electron's redirected JSON-RPC pipes.
+        proc = _spawn_windows_node([NODE_COMMAND, str(runtime), *args], env)
         return proc.wait()
     os.execve(NODE_COMMAND, [NODE_COMMAND, str(runtime), *args], env)
     return 127


### PR DESCRIPTION
## 背景

修复 Issue #11（Windows 11 + ZCode 3.9.2）：注入后输入框、模型切换和新建任务无响应。


## 实现

- Windows wrapper 使用父进程 `stdin/stdout/stderr` 的 binary OS stream 启动 agent-server。
- 设置 `close_fds=True`，让 CPython 在 Windows 上仅继承显式绑定的三个句柄，保持 stderr 与 stdout 分离。
- 启动前校验句柄可用性，失败时快速返回可诊断错误；wrapper 只等待子进程并传播退出码。
- 增加多帧 JSON-RPC 风格输入、实时 stdout、stderr 隔离和非零退出码测试。
- 更新 Windows wrapper 通信参考文档与 Unreleased changelog。

## 验证

- Python 3.9：`43 passed, 1 skipped`
- Python 3.14：`uv run --with pytest --python /opt/homebrew/bin/python3.14 pytest -q` -> `43 passed, 1 skipped`
- Python 3.14：`py_compile` 通过
- `git diff --check` 通过
- GitHub Actions 将在 Windows/macOS × Python 3.10/3.14 矩阵上运行。

## Windows 实机验收（待执行）

Issue 正文标注了 `install (--dry-run)`，但 UI 卡死只能通过实际安装复现。因此需要在 Windows 11 + ZCode 3.9.2 上执行：

1. `py zcode-keysmith.py install --yes`（不是仅 `--dry-run`），记录 `doctor`、`verify` 和 `logs/wrapper-start.jsonl`。
2. 完全退出并重启 ZCode。
3. 验证输入框可输入、模型切换可用、新建任务成功，并运行长会话确认多帧 JSON-RPC 不断连。
4. 如失败，保留 ZCode/Python 版本、脱敏日志和退出码；不上传 token/cookie/API key。

Closes #11
