### PR TITLE
docs: README rework

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,18 +1,15 @@
 <!-- markdownlint-disable MD013 MD033 MD041 -->
 
 <p align="center">
-  <img src="docs/assets/readme/zcode-keysmith-preview.png" alt="Illustrative zcode-keysmith install preview; actual paths and output vary" width="100%">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/readme/deploy-flow-en-dark.svg">
+    <img src="docs/assets/readme/deploy-flow-en-light.svg" alt="zcode-keysmith deployment flow: preview → apply system-role + wrapper → verify → undo" width="100%">
+  </picture>
 </p>
-<p align="center"><em>Illustrative preview / 示意预览；actual paths and output follow the local dry-run.</em></p>
 
 <h1 align="center">zcode-keysmith</h1>
 
-<p align="center">Preview-first ZCode App system-role entrypoint for macOS and Windows that you can verify and undo.</p>
-
-<p align="center">
-  <img alt="Source version v0.2.1" src="https://img.shields.io/badge/source-v0.2.1-0099CC">
-  <img alt="License MIT" src="https://img.shields.io/badge/license-MIT-6DB33F">
-</p>
+<p align="center">Preview-first ZCode App user-dir system-role entrypoint you can verify and undo.</p>
 
 <p align="center">
   <a href="README.md">简体中文</a> ·
@@ -22,14 +19,20 @@
   <a href="LICENSE">License</a>
 </p>
 
-## English
+<p align="center">
+  <img alt="GitHub Stars" src="https://img.shields.io/github/stars/Jia-Ethan/zcode-keysmith?style=flat-square&color=%232f81f7">
+  <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10+-3776AB?style=flat-square&logo=python&logoColor=white">
+  <img alt="License MIT" src="https://img.shields.io/badge/license-MIT-6DB33F?style=flat-square">
+</p>
 
-The Keysmith series **deploys, verifies, and revokes** custom instructions for local AI tools. `zcode-keysmith` installs a managed `system-role.md` in the user directory and routes it through an agent-server wrapper into ZCode's runtime system-message path. It is **not** an `AGENTS.md` installer; `v0.2.1` includes the Desktop client source.
+## English 🇬🇧
+
+The Keysmith series **deploys, verifies, and revokes** custom instructions for local AI tools. `zcode-keysmith` installs a managed `system-role.md` in the user directory and routes it through an agent-server wrapper into ZCode's runtime system-message path. It is **not** an `AGENTS.md` installer; source-only, with no Desktop.
 
 > [!WARNING]
-> This changes the local ZCode **agent-server entrypoint** for later newly started sessions. The app bundle stays untouched; API keys, provider settings, and MCP are never read. macOS and Windows 10/11 are supported. Commands preview unless you pass `--yes`. Read [`examples/system-role.md`](examples/system-role.md) and [`docs/reference.md`](docs/reference.md) first.
+> This changes the local ZCode **agent-server entrypoint** for later newly started sessions: it writes `~/.zcode-keysmith/system-role.md` and the wrapper, then activates a macOS LaunchAgent or the current-user Windows `ZCODE_*` environment. The app bundle stays untouched; API keys, provider settings, and MCP are never read. Commands preview unless you pass `--yes`. Read [`examples/system-role.md`](examples/system-role.md) and [`docs/reference.md`](docs/reference.md) first.
 
-### Which Keysmith to use
+### Which Keysmith to use 🔑
 
 | Project | Target | Surface | Conservative install | Desktop |
 | --- | --- | --- | --- | --- |
@@ -38,42 +41,50 @@ The Keysmith series **deploys, verifies, and revokes** custom instructions for l
 | [grok-keysmith](https://github.com/Jia-Ethan/grok-keysmith) | Grok Build | Global `~/.grok/rules` (does not edit `AGENTS.md`) | Stable CLI Release | Unsigned Beta |
 | **[zcode-keysmith](https://github.com/Jia-Ethan/zcode-keysmith)** | ZCode App | User-dir system-role + wrapper | Source only | None |
 
-### Install options
+### Install options 📦
 
-**Source install only.** Use the GitHub-generated source archive from [`v0.2.1`](https://github.com/Jia-Ethan/zcode-keysmith/releases/tag/v0.2.1), or clone this repo and run `python3 zcode-keysmith.py`. There are currently no standalone binary assets or pip/npm package.
+1. **Conservative: source only.** There is no standalone CLI package, no Desktop, and no checkout-able Release tag. Clone this repository's `master` branch, confirm `--version` is `0.2.1`, and verify the SHA-256 of `examples/system-role.md`. Do not download only `zcode-keysmith.py`.
+2. **Let an agent install it.** Copy the instruction template from [`docs/agent-install.md`](docs/agent-install.md) and have Codex / Claude Code / any execution agent do the verification and deployment for you.
 
-### Windows quick start
+### Quick start 🚀
 
-Quit ZCode, then run in PowerShell:
-
-```powershell
-py zcode-keysmith.py install --dry-run
-py zcode-keysmith.py install --yes
-py zcode-keysmith.py doctor
-```
-
-Reopen ZCode, start a fresh task, then run `py zcode-keysmith.py verify`. ZCode is auto-detected from running processes, App Paths, and common install directories. For a custom install:
-
-```powershell
-py zcode-keysmith.py install --zcode-app "D:\software\zcode" --dry-run
-```
-
-The Windows installer uses current-user environment values and needs no administrator access.
-
-### macOS quick start
+**Source (macOS):**
 
 ```bash
 git clone https://github.com/Jia-Ethan/zcode-keysmith.git
 cd zcode-keysmith
 python3 zcode-keysmith.py --version
+# expected zcode-keysmith.py 0.2.1
+shasum -a 256 examples/system-role.md
+# expected ea1d678e9aa72056259ad5e1ccacdff486a07581c1c09d6e5c36e5e91dadd954
 python3 zcode-keysmith.py install --dry-run
+# After reviewing the ~/.zcode-keysmith target, system-role, and wrapper plan:
 python3 zcode-keysmith.py install --yes
 python3 zcode-keysmith.py doctor
 ```
 
-Quit and reopen ZCode, start a fresh task, then run `python3 zcode-keysmith.py verify`. Use `--zcode-app` or `ZCODE_APP_PATH` for a non-default app. `install --dry-run` still needs a local patchable runtime.
+Quit ZCode completely, reopen it, start a fresh task, then run `python3 zcode-keysmith.py verify`.
 
-### What it changes
+**Windows PowerShell:**
+
+Quit ZCode first, then:
+
+```powershell
+git clone https://github.com/Jia-Ethan/zcode-keysmith.git
+cd zcode-keysmith
+py zcode-keysmith.py --version
+# expected zcode-keysmith.py 0.2.1
+py zcode-keysmith.py install --dry-run
+# After reviewing the ~/.zcode-keysmith target, system-role, and wrapper plan:
+py zcode-keysmith.py install --yes
+py zcode-keysmith.py doctor
+```
+
+Reopen ZCode, start a fresh task, then run `py zcode-keysmith.py verify`. ZCode is auto-detected from running processes, App Paths, and common install directories.
+
+The machine must already have `ZCode.app` or `ZCode.exe`. `install --dry-run` still reads the source prompt and checks that the runtime is patchable; preview fails if no recognizable install is present. Use `--zcode-app` or `ZCODE_APP_PATH` for a non-default location.
+
+### What it touches ✍️
 
 | Path | What happens |
 | --- | --- |
@@ -83,21 +94,57 @@ Quit and reopen ZCode, start a fresh task, then run `python3 zcode-keysmith.py v
 | Seven `ZCODE_*` values under `HKCU\Environment` | Windows current-user entrypoint; no admin access |
 | `cache/`, `logs/` | Runtime cache and wrapper logs; not removed on uninstall |
 
-No project files are written; `ZCode.app` is not modified. Design: [`docs/reference.md`](docs/reference.md).
+No project files are written; `ZCode.app` / `ZCode.exe` is not modified. Design: [`docs/reference.md`](docs/reference.md).
 
-### How to undo
+### How to undo ♻️
 
 ```bash
 python3 zcode-keysmith.py uninstall --dry-run
 python3 zcode-keysmith.py uninstall --yes
 ```
 
-On Windows, replace `python3` with `py`. macOS uninstall renames five managed files and clears launchd. Windows uninstall backs up four managed files and restores pre-install user environment values only if Keysmith still owns the current values, so later manual changes are preserved. Full steps: [`docs/reference.md`](docs/reference.md).
+On Windows, replace `python3` with `py`. macOS uninstall renames five managed files and clears launchd. Windows uninstall backs up four managed files and restores pre-install user environment values only if Keysmith still owns the current values. There is no `recover` / `restore`. Full steps: [`docs/reference.md`](docs/reference.md).
 
-### Platforms and limits
+### Platforms and limits ⚠️
 
-Documented support is macOS with a local `ZCode.app`, and Windows 10/11 with a local `ZCode.exe`. The `v0.2.1` Release provides only GitHub-generated source archives; desktop installers are not yet published. Python 3.10+ is recommended; Windows must retain the Python interpreter used during install.
+- CLI CI covers macOS / Windows; Python 3.10+. Linux is not documented. Windows must retain the Python interpreter used during install.
+- Source-only: no signed package, no Desktop, no standalone binary assets, no stable Release tag. The current public tree is `0.2.1`.
+- Wrapper logs, observability fields, and uninstall leftovers are documented in [`docs/reference.md`](docs/reference.md).
 
-### Advanced docs, contributing, and the series
+### Project layout 🗂️
 
-Design, fields, and uninstall leftovers: [`docs/reference.md`](docs/reference.md). Agent install: [`docs/agent-install.md`](docs/agent-install.md). Before a patch, run `python3 -m py_compile zcode-keysmith.py` and `python3 -m pytest tests -q`. The installer never reads API keys. Official feedback: [GitHub Discussions](https://github.com/Jia-Ethan/zcode-keysmith/discussions/7). Community: [LINUX DO](https://linux.do). The core series is only the four projects in the table above.
+```text
+zcode-keysmith/
+├── zcode-keysmith.py              # deployment CLI: preview / install / uninstall
+├── examples/system-role.md        # bundled system-role source
+├── tests/                         # installer regression
+├── docs/reference.md              # full command reference and internals
+├── docs/agent-install.md          # agent install instruction template
+├── docs/assets/readme/            # README diagrams (light/dark pairs)
+└── tools/gen_readme_assets.py     # deploy-flow SVG generator (light/dark)
+```
+
+### Advanced docs 📚
+
+- Entrypoint / wrapper / uninstall leftovers: [`docs/reference.md`](docs/reference.md)
+- Agent install: [`docs/agent-install.md`](docs/agent-install.md)
+
+### Contributing, security, and the series 🤝
+
+The installer never reads API keys. Official feedback: [GitHub Discussions](https://github.com/Jia-Ethan/zcode-keysmith/discussions/7). Community: [LINUX DO](https://linux.do).
+
+- [codex-keysmith](https://github.com/Jia-Ethan/codex-keysmith) — global Codex instructions
+- [claude-keysmith](https://github.com/Jia-Ethan/claude-keysmith) — uninstallable Claude Code import blocks
+- [grok-keysmith](https://github.com/Jia-Ethan/grok-keysmith) — Grok Build home rules (`~/.grok/rules/99-keysmith.md`; does not edit `AGENTS.md`)
+- [zcode-keysmith](https://github.com/Jia-Ethan/zcode-keysmith) — ZCode App system-role entrypoint (source only, no Desktop)
+
+### Star History ⭐
+
+<p align="center">
+  <a href="https://star-history.com/#Jia-Ethan/zcode-keysmith&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Jia-Ethan/zcode-keysmith&type=Date&theme=dark">
+      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Jia-Ethan/zcode-keysmith&type=Date">
+    </picture>
+  </a>
+</p>

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
 <!-- markdownlint-disable MD013 MD033 MD041 -->
 
 <p align="center">
-  <img src="docs/assets/readme/zcode-keysmith-preview.png" alt="Illustrative zcode-keysmith install preview; actual paths and output vary" width="100%">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/assets/readme/deploy-flow-zh-dark.svg">
+    <img src="docs/assets/readme/deploy-flow-zh-light.svg" alt="zcode-keysmith 部署流程：预览 → 写入 system-role + wrapper → 验证 → 撤销" width="100%">
+  </picture>
 </p>
-<p align="center"><em>Illustrative preview / 示意预览；实际路径与输出以本机 dry-run 为准。</em></p>
 
 <h1 align="center">zcode-keysmith</h1>
 
-<p align="center">先预览、再写入、可撤销的 ZCode App system-role 入口安装器，支持 macOS 与 Windows。</p>
-
-<p align="center">
-  <img alt="Source version v0.2.1" src="https://img.shields.io/badge/source-v0.2.1-0099CC">
-  <img alt="License MIT" src="https://img.shields.io/badge/license-MIT-6DB33F">
-</p>
+<p align="center">先预览、再写入、可撤销的 ZCode App 用户目录 system-role 入口安装器。</p>
 
 <p align="center">
   <a href="#简体中文">简体中文</a> ·
@@ -22,64 +19,72 @@
   <a href="LICENSE">License</a>
 </p>
 
-## 简体中文
+<p align="center">
+  <img alt="GitHub Stars" src="https://img.shields.io/github/stars/Jia-Ethan/zcode-keysmith?style=flat-square&color=%232f81f7">
+  <img alt="Python 3.10+" src="https://img.shields.io/badge/Python-3.10+-3776AB?style=flat-square&logo=python&logoColor=white">
+  <img alt="License MIT" src="https://img.shields.io/badge/license-MIT-6DB33F?style=flat-square">
+</p>
 
-Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指令。`zcode-keysmith` 在用户目录安装受管理的 `system-role.md`，经 agent-server wrapper 进入 ZCode runtime 的 system message 路径。**不是** `AGENTS.md` 安装器；`v0.2.1` 提供桌面客户端源码。
+## 简体中文 🇨🇳
+
+Keysmith 系列为本地 AI 工具**安全部署、验证和撤销**自定义指令。`zcode-keysmith` 在用户目录安装受管理的 `system-role.md`，经 agent-server wrapper 进入 ZCode runtime 的 system message 路径。**不是** `AGENTS.md` 安装器；仅源码安装，无 Desktop。
 
 > [!WARNING]
-> 这会改本机 ZCode 的 **agent-server 入口**，影响之后新启动的会话。不改 App 原包，不读 API key / provider / MCP。支持 macOS 与 Windows 10/11。默认只预览，显式 `--yes` 才写入。先阅读 [`examples/system-role.md`](examples/system-role.md) 和 [`docs/reference.md`](docs/reference.md)。
+> 这会改本机 ZCode 的 **agent-server 入口**，影响之后新启动的会话：写入 `~/.zcode-keysmith/system-role.md` 与 wrapper，并激活 macOS LaunchAgent 或 Windows 当前用户 `ZCODE_*` 环境。不改 App 原包，不读 API key / provider / MCP。默认只预览，显式 `--yes` 才写入。先阅读 [`examples/system-role.md`](examples/system-role.md) 和 [`docs/reference.md`](docs/reference.md)。
 
-### 选择哪个 Keysmith
+### 选择哪个 Keysmith 🔑
 
 | 项目 | 目标工具 | 部署面 | 稳妥安装 | Desktop |
 | --- | --- | --- | --- | --- |
 | [codex-keysmith](https://github.com/Jia-Ethan/codex-keysmith) | Codex | 全局 `~/.codex` 指令 | 稳定 CLI Release | 未签名 Beta |
 | [claude-keysmith](https://github.com/Jia-Ethan/claude-keysmith) | Claude Code | 项目 / 用户 `CLAUDE.md` import | 源码 CLI | 未签名 Beta |
 | [grok-keysmith](https://github.com/Jia-Ethan/grok-keysmith) | Grok Build | 全局 `~/.grok/rules`（不改 `AGENTS.md`） | 稳定 CLI Release | 未签名 Beta |
-| **[zcode-keysmith](https://github.com/Jia-Ethan/zcode-keysmith)** | ZCode App | 用户目录 system-role + wrapper | 仅源码 | 源码已提供 |
+| **[zcode-keysmith](https://github.com/Jia-Ethan/zcode-keysmith)** | ZCode App | 用户目录 system-role + wrapper | 仅源码 | 无 |
 
-### 安装方式
+### 安装方式 📦
 
-**只有源码安装。** 使用 [`v0.2.1`](https://github.com/Jia-Ethan/zcode-keysmith/releases/tag/v0.2.1) 的 GitHub 自动源码归档，或 clone 本仓库后运行 `python3 zcode-keysmith.py`。当前没有独立二进制资产或 `pip` / npm 安装包。
+1. **稳妥：仅源码。** 没有独立 CLI 安装包、没有 Desktop、没有可检出的 Release tag。clone 本仓库 `master` 后校验 `--version` 为 `0.2.1`，并校验 `examples/system-role.md` 的 SHA-256。不要只下载 `zcode-keysmith.py`。
+2. **交给智能体装。** 复制 [`docs/agent-install.md`](docs/agent-install.md) 里的指令模板，让 Codex / Claude Code / 任何执行型智能体替你完成校验与部署。
 
-### Windows 快速开始
+### 快速开始 🚀
 
-先完全退出 ZCode，在 PowerShell 中运行：
-
-```powershell
-py zcode-keysmith.py install --dry-run
-py zcode-keysmith.py install --yes
-py zcode-keysmith.py doctor
-```
-
-重新打开 ZCode，新建任务后运行：
-
-```powershell
-py zcode-keysmith.py verify
-```
-
-安装器会自动查找正在运行的 `ZCode.exe`、注册的 App Path 和常见安装目录。自定义安装目录也可以显式指定，例如：
-
-```powershell
-py zcode-keysmith.py install --zcode-app "D:\software\zcode" --dry-run
-```
-
-Windows 版把入口写入当前用户环境变量，不需要管理员权限；用 ZCode 自带的 Electron/Node 运行缓存 runtime，并用当前 Python 解释器启动受管理 wrapper。
-
-### macOS 快速开始
+**源码（macOS）：**
 
 ```bash
 git clone https://github.com/Jia-Ethan/zcode-keysmith.git
 cd zcode-keysmith
 python3 zcode-keysmith.py --version
+# 期望 zcode-keysmith.py 0.2.1
+shasum -a 256 examples/system-role.md
+# 期望 ea1d678e9aa72056259ad5e1ccacdff486a07581c1c09d6e5c36e5e91dadd954
 python3 zcode-keysmith.py install --dry-run
+# 确认 ~/.zcode-keysmith 目标、system-role 与 wrapper 计划后：
 python3 zcode-keysmith.py install --yes
 python3 zcode-keysmith.py doctor
 ```
 
-退出并重新打开 ZCode，新建任务后再运行 `python3 zcode-keysmith.py verify`。非默认 App 路径用 `--zcode-app` 或 `ZCODE_APP_PATH`。两端的 `install --dry-run` 都需要能读到可打补丁的本机 runtime。
+完全退出并重新打开 ZCode，新建任务后再运行 `python3 zcode-keysmith.py verify`。
 
-### 会修改什么
+**Windows PowerShell：**
+
+先完全退出 ZCode，再运行：
+
+```powershell
+git clone https://github.com/Jia-Ethan/zcode-keysmith.git
+cd zcode-keysmith
+py zcode-keysmith.py --version
+# 期望 zcode-keysmith.py 0.2.1
+py zcode-keysmith.py install --dry-run
+# 确认 ~/.zcode-keysmith 目标、system-role 与 wrapper 计划后：
+py zcode-keysmith.py install --yes
+py zcode-keysmith.py doctor
+```
+
+重新打开 ZCode，新建任务后运行 `py zcode-keysmith.py verify`。安装器会自动查找正在运行的 `ZCode.exe`、注册的 App Path 和常见安装目录。
+
+本机需要先有 `ZCode.app` 或 `ZCode.exe`。`install --dry-run` 仍会读取源提示词并检查 runtime 是否可打补丁；找不到可识别安装时预览会失败。非默认路径用 `--zcode-app` 或 `ZCODE_APP_PATH`。
+
+### 会修改什么 ✍️
 
 | 路径 | 会发生什么 |
 | --- | --- |
@@ -89,21 +94,57 @@ python3 zcode-keysmith.py doctor
 | `HKCU\Environment` 的七个 `ZCODE_*` 值 | Windows 当前用户入口；不需要管理员权限 |
 | `cache/`、`logs/` | 运行时缓存与 wrapper 日志；卸载不删 |
 
-不写项目文件，不改 `ZCode.app`。原理见 [`docs/reference.md`](docs/reference.md)。
+不写项目文件，不改 `ZCode.app` / `ZCode.exe`。原理见 [`docs/reference.md`](docs/reference.md)。
 
-### 如何撤销
+### 如何撤销 ♻️
 
 ```bash
 python3 zcode-keysmith.py uninstall --dry-run
 python3 zcode-keysmith.py uninstall --yes
 ```
 
-Windows 也可以把上面的 `python3` 换成 `py`。macOS 卸载把五个受管理文件改名为 `.bak_*` 并清空当前 launchd 环境；Windows 卸载备份四个受管理文件，并且只在注册表值仍属于本次安装时恢复安装前的用户环境，避免覆盖之后的人工修改。没有 `recover` / `restore`，完整步骤见 [`docs/reference.md`](docs/reference.md)。
+Windows 把 `python3` 换成 `py`。macOS 卸载把五个受管理文件改名为 `.bak_*` 并清空当前 launchd 环境；Windows 卸载备份四个受管理文件，并且只在注册表值仍属于本次安装时恢复安装前的用户环境。没有 `recover` / `restore`，完整步骤见 [`docs/reference.md`](docs/reference.md)。
 
-### 平台与限制
+### 平台与限制 ⚠️
 
-文档化支持为 macOS + 本机 `ZCode.app`，以及 Windows 10/11 + 本机 `ZCode.exe`。`v0.2.1` Release 仅提供 GitHub 自动源码归档；桌面安装包尚未发布。推荐 Python 3.10+；Windows 运行期间不能删除安装时使用的 Python。
+- CLI CI 覆盖 macOS / Windows；Python 3.10+。Linux 没有文档化支持。Windows 运行期间不能删除安装时使用的 Python。
+- 仅源码安装：无签名包、无 Desktop、无独立二进制资产、无稳定 Release tag。当前公开树版本是 `0.2.1`。
+- 开发版字段、wrapper 日志与卸载残留见 [`docs/reference.md`](docs/reference.md)。
 
-### 进阶文档 · 贡献 · 系列
+### 项目结构 🗂️
 
-原理、字段与卸载残留见 [`docs/reference.md`](docs/reference.md)；智能体安装见 [`docs/agent-install.md`](docs/agent-install.md)。提交前运行 `python3 -m py_compile zcode-keysmith.py` 与 `python3 -m pytest tests -q`。安装器不读取 API key。官方反馈：[GitHub Discussions](https://github.com/Jia-Ethan/zcode-keysmith/discussions/7)；社区交流：[LINUX DO](https://linux.do)。核心系列只有对照表中的四个项目。
+```text
+zcode-keysmith/
+├── zcode-keysmith.py              # 部署 CLI：preview / install / uninstall
+├── examples/system-role.md        # 内置 system-role 源文件
+├── tests/                         # 安装器回归
+├── docs/reference.md              # 完整命令参考与内部机制
+├── docs/agent-install.md          # 智能体安装指令模板
+├── docs/assets/readme/            # README 图示（明/暗双版本）
+└── tools/gen_readme_assets.py     # 部署流程图生成（明/暗双版本）
+```
+
+### 进阶文档 📚
+
+- 入口 / wrapper / 卸载残留：[`docs/reference.md`](docs/reference.md)
+- 智能体安装：[`docs/agent-install.md`](docs/agent-install.md)
+
+### 贡献、安全与系列 🤝
+
+安装器不读取 API key。官方反馈：[GitHub Discussions](https://github.com/Jia-Ethan/zcode-keysmith/discussions/7)；社区交流：[LINUX DO](https://linux.do)。
+
+- [codex-keysmith](https://github.com/Jia-Ethan/codex-keysmith) — Codex 全局指令
+- [claude-keysmith](https://github.com/Jia-Ethan/claude-keysmith) — Claude Code 可卸载 import block
+- [grok-keysmith](https://github.com/Jia-Ethan/grok-keysmith) — Grok Build home rules（`~/.grok/rules/99-keysmith.md`，不改 `AGENTS.md`）
+- [zcode-keysmith](https://github.com/Jia-Ethan/zcode-keysmith) — ZCode App system-role 入口（仅源码，无 Desktop）
+
+### Star History ⭐
+
+<p align="center">
+  <a href="https://star-history.com/#Jia-Ethan/zcode-keysmith&Date">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=Jia-Ethan/zcode-keysmith&type=Date&theme=dark">
+      <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=Jia-Ethan/zcode-keysmith&type=Date">
+    </picture>
+  </a>
+</p>

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -2,48 +2,14 @@
 
 # 复制给智能体安装 / Copy this to an agent
 
-把下面这段话复制给 Codex、Claude Code、Cursor Agent、ChatGPT Agent 或其他本地智能体。执行流程只有一次确认：确认是否写入持久化入口文件。
+## 简体中文
 
 ```text
-请使用 https://github.com/Jia-Ethan/zcode-keysmith 帮我安装 ZCode App 的 managed true system-role entrypoint。
-
-执行要求：
-1. 先阅读 README.md 和 zcode-keysmith.py。
-2. 识别当前平台；Windows 使用 `py`，macOS 使用 `python3`。运行对应的 `zcode-keysmith.py install --dry-run`。
-3. 向我展示将写入的准确路径，必须包括：
-   - ~/.zcode-keysmith/system-role.md
-   - ~/.zcode-keysmith/config.json
-   - ~/.zcode-keysmith/bin/zcode-agent-wrapper.py
-   - Windows：~/.zcode-keysmith/bin/zcode-keysmith-env.ps1 和 HKCU\Environment 的 ZCODE_* 值
-   - macOS：~/.zcode-keysmith/bin/zcode-keysmith-env.sh 和 ~/Library/LaunchAgents/com.jia.zcode-keysmith.env.plist
-4. 同时展示将使用的 ZCode runtime 路径、ZCode node command 路径、agent-server args，以及 app_bundle_modified: false。
-5. API key、token、MCP 配置、ZCode provider 配置由 ZCode 自身管理；安装器不读取、不保存、不打印这些内容。
-6. 只问我一次：是否确认写入以上持久化入口文件。
-7. 我确认后，用当前平台对应的 Python 命令运行 `zcode-keysmith.py install --yes`。
-8. 写入后运行 `doctor`。
-9. 再运行 `verify`。
-10. 提醒我重新打开 ZCode，然后新建任务测试"你是谁"。测试后再次运行 verify，确认 wrapper_invoked: true。
+请从公开仓库 https://github.com/Jia-Ethan/zcode-keysmith 安装 zcode-keysmith 0.2.1。只 clone 当前 `master` 源码树，不要虚构 Release ZIP / tag 检出；检出后确认 `python3 zcode-keysmith.py --version`（Windows 用 `py`）输出 `0.2.1`，并校验 examples/system-role.md 的 SHA-256 为 `ea1d678e9aa72056259ad5e1ccacdff486a07581c1c09d6e5c36e5e91dadd954`。识别当前平台：Windows 使用 `py`，macOS 使用 `python3`。运行 --version、install --dry-run 和 doctor，报告目标 ~/.zcode-keysmith 目录、内置提示词来源与 SHA-256、将写入的 system-role.md / config.json / wrapper / env 脚本路径、macOS LaunchAgent 或 Windows HKCU\Environment 的 ZCODE_* 计划、ZCode runtime 与 node command 路径，以及 app_bundle_modified: false。默认只预览；等我明确确认后才添加 --yes。写入后运行 doctor 与 verify。提醒我完全退出并重新打开 ZCode，新建任务后再运行 verify，确认 wrapper_invoked: true。不要删除任何备份，不修改 ZCode 原包、网络、运行中进程、API key、token、cookie、MCP 或 provider 配置。
 ```
 
-English version:
+## English
 
 ```text
-Use https://github.com/Jia-Ethan/zcode-keysmith to install the managed true system-role entrypoint for my local ZCode App.
-
-Requirements:
-1. Read README.md and zcode-keysmith.py first.
-2. Detect the platform; use `py` on Windows and `python3` on macOS. Run the matching `zcode-keysmith.py install --dry-run` command.
-3. Show the exact write targets:
-   - ~/.zcode-keysmith/system-role.md
-   - ~/.zcode-keysmith/config.json
-   - ~/.zcode-keysmith/bin/zcode-agent-wrapper.py
-   - Windows: ~/.zcode-keysmith/bin/zcode-keysmith-env.ps1 and ZCODE_* values under HKCU\Environment
-   - macOS: ~/.zcode-keysmith/bin/zcode-keysmith-env.sh and ~/Library/LaunchAgents/com.jia.zcode-keysmith.env.plist
-4. Also show the ZCode runtime path, ZCode node command path, agent-server args, and app_bundle_modified: false.
-5. API keys, tokens, MCP config, and provider config stay managed by ZCode. The installer must not read, store, or print them.
-6. Ask once whether to write the managed entrypoint files.
-7. After confirmation, run `zcode-keysmith.py install --yes` with the platform's Python command.
-8. Then run `doctor`.
-9. Then run `verify`.
-10. Tell me to reopen ZCode and test a fresh task with "Who are you?". After the test, run verify again and confirm wrapper_invoked: true.
+Install zcode-keysmith 0.2.1 from the public repository https://github.com/Jia-Ethan/zcode-keysmith. Clone the current `master` source tree only; do not invent a Release ZIP or tag checkout. After checkout, confirm that `python3 zcode-keysmith.py --version` (`py` on Windows) reports `0.2.1`, and verify that the SHA-256 of examples/system-role.md is `ea1d678e9aa72056259ad5e1ccacdff486a07581c1c09d6e5c36e5e91dadd954`. Detect the platform; use `py` on Windows and `python3` on macOS. Run --version, install --dry-run, and doctor, then report the target ~/.zcode-keysmith directory, the bundled prompt source and its SHA-256, the planned system-role.md / config.json / wrapper / env-script paths, the macOS LaunchAgent or Windows HKCU\Environment ZCODE_* plan, the ZCode runtime and node-command paths, and app_bundle_modified: false. Preview only by default; wait for my explicit confirmation before adding --yes. After writing, run doctor and verify. Tell me to quit and reopen ZCode, start a fresh task, then run verify again and confirm wrapper_invoked: true. Do not delete any backups, and do not modify the ZCode app bundle, network, running processes, API keys, tokens, cookies, MCP, or provider config.
 ```

--- a/docs/assets/readme/deploy-flow-en-dark.svg
+++ b/docs/assets/readme/deploy-flow-en-dark.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1230" height="252" viewBox="0 0 1230 252" font-family="-apple-system, 'Segoe UI', 'Noto Sans', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif">
+<rect width="1230" height="252" fill="#0d1117"/>
+<rect x="28" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="28" y="74" width="265" height="34" rx="10" fill="#121d2f"/>
+<rect x="28" y="98" width="265" height="10" fill="#121d2f"/>
+<text x="44" y="97" font-size="15" font-weight="600" fill="#58a6ff">1 Preview</text>
+<text x="44" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">--dry-run</text>
+<text x="44" y="162" font-size="12.5" fill="#8b949e">Review ~/.zcode-keysmith, the</text>
+<text x="44" y="180" font-size="12.5" fill="#8b949e">system-role, and wrapper plan</text>
+<path d="M 300 142.0 L 322 148.0 L 300 154.0" fill="none" stroke="#8b949e" stroke-width="1.6"/>
+<rect x="331" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="331" y="74" width="265" height="34" rx="10" fill="#121d2f"/>
+<rect x="331" y="98" width="265" height="10" fill="#121d2f"/>
+<text x="347" y="97" font-size="15" font-weight="600" fill="#58a6ff">2 Apply</text>
+<text x="347" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">--yes</text>
+<text x="347" y="162" font-size="12.5" fill="#8b949e">Write system-role.md and wrapper,</text>
+<text x="347" y="180" font-size="12.5" fill="#8b949e">activate the user-dir entrypoint</text>
+<path d="M 603 142.0 L 625 148.0 L 603 154.0" fill="none" stroke="#8b949e" stroke-width="1.6"/>
+<rect x="634" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="634" y="74" width="265" height="34" rx="10" fill="#12261e"/>
+<rect x="634" y="98" width="265" height="10" fill="#12261e"/>
+<text x="650" y="97" font-size="15" font-weight="600" fill="#3fb950">3 Verify</text>
+<text x="650" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">new session</text>
+<text x="650" y="162" font-size="12.5" fill="#8b949e">Quit and reopen ZCode, start a</text>
+<text x="650" y="180" font-size="12.5" fill="#8b949e">fresh task; verify wrapper invoked</text>
+<path d="M 906 142.0 L 928 148.0 L 906 154.0" fill="none" stroke="#8b949e" stroke-width="1.6"/>
+<rect x="937" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="937" y="74" width="265" height="34" rx="10" fill="#12261e"/>
+<rect x="937" y="98" width="265" height="10" fill="#12261e"/>
+<text x="953" y="97" font-size="15" font-weight="600" fill="#3fb950">4 Undo</text>
+<text x="953" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">uninstall</text>
+<text x="953" y="162" font-size="12.5" fill="#8b949e">Preview the full uninstall plan,</text>
+<text x="953" y="180" font-size="12.5" fill="#8b949e">then add --yes to restore</text>
+</svg>

--- a/docs/assets/readme/deploy-flow-en-light.svg
+++ b/docs/assets/readme/deploy-flow-en-light.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1230" height="252" viewBox="0 0 1230 252" font-family="-apple-system, 'Segoe UI', 'Noto Sans', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif">
+<rect width="1230" height="252" fill="#ffffff"/>
+<rect x="28" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="28" y="74" width="265" height="34" rx="10" fill="#ddf4ff"/>
+<rect x="28" y="98" width="265" height="10" fill="#ddf4ff"/>
+<text x="44" y="97" font-size="15" font-weight="600" fill="#0969da">1 Preview</text>
+<text x="44" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">--dry-run</text>
+<text x="44" y="162" font-size="12.5" fill="#57606a">Review ~/.zcode-keysmith, the</text>
+<text x="44" y="180" font-size="12.5" fill="#57606a">system-role, and wrapper plan</text>
+<path d="M 300 142.0 L 322 148.0 L 300 154.0" fill="none" stroke="#57606a" stroke-width="1.6"/>
+<rect x="331" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="331" y="74" width="265" height="34" rx="10" fill="#ddf4ff"/>
+<rect x="331" y="98" width="265" height="10" fill="#ddf4ff"/>
+<text x="347" y="97" font-size="15" font-weight="600" fill="#0969da">2 Apply</text>
+<text x="347" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">--yes</text>
+<text x="347" y="162" font-size="12.5" fill="#57606a">Write system-role.md and wrapper,</text>
+<text x="347" y="180" font-size="12.5" fill="#57606a">activate the user-dir entrypoint</text>
+<path d="M 603 142.0 L 625 148.0 L 603 154.0" fill="none" stroke="#57606a" stroke-width="1.6"/>
+<rect x="634" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="634" y="74" width="265" height="34" rx="10" fill="#dafbe1"/>
+<rect x="634" y="98" width="265" height="10" fill="#dafbe1"/>
+<text x="650" y="97" font-size="15" font-weight="600" fill="#1a7f37">3 Verify</text>
+<text x="650" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">new session</text>
+<text x="650" y="162" font-size="12.5" fill="#57606a">Quit and reopen ZCode, start a</text>
+<text x="650" y="180" font-size="12.5" fill="#57606a">fresh task; verify wrapper invoked</text>
+<path d="M 906 142.0 L 928 148.0 L 906 154.0" fill="none" stroke="#57606a" stroke-width="1.6"/>
+<rect x="937" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="937" y="74" width="265" height="34" rx="10" fill="#dafbe1"/>
+<rect x="937" y="98" width="265" height="10" fill="#dafbe1"/>
+<text x="953" y="97" font-size="15" font-weight="600" fill="#1a7f37">4 Undo</text>
+<text x="953" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">uninstall</text>
+<text x="953" y="162" font-size="12.5" fill="#57606a">Preview the full uninstall plan,</text>
+<text x="953" y="180" font-size="12.5" fill="#57606a">then add --yes to restore</text>
+</svg>

--- a/docs/assets/readme/deploy-flow-zh-dark.svg
+++ b/docs/assets/readme/deploy-flow-zh-dark.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1230" height="252" viewBox="0 0 1230 252" font-family="-apple-system, 'Segoe UI', 'Noto Sans', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif">
+<rect width="1230" height="252" fill="#0d1117"/>
+<rect x="28" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="28" y="74" width="265" height="34" rx="10" fill="#121d2f"/>
+<rect x="28" y="98" width="265" height="10" fill="#121d2f"/>
+<text x="44" y="97" font-size="15" font-weight="600" fill="#58a6ff">1 预览</text>
+<text x="44" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">--dry-run</text>
+<text x="44" y="162" font-size="12.5" fill="#8b949e">查看 ~/.zcode-keysmith 目标、</text>
+<text x="44" y="180" font-size="12.5" fill="#8b949e">system-role 与 wrapper 计划</text>
+<path d="M 300 142.0 L 322 148.0 L 300 154.0" fill="none" stroke="#8b949e" stroke-width="1.6"/>
+<rect x="331" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="331" y="74" width="265" height="34" rx="10" fill="#121d2f"/>
+<rect x="331" y="98" width="265" height="10" fill="#121d2f"/>
+<text x="347" y="97" font-size="15" font-weight="600" fill="#58a6ff">2 写入</text>
+<text x="347" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">--yes</text>
+<text x="347" y="162" font-size="12.5" fill="#8b949e">写入 system-role.md 与 wrapper，</text>
+<text x="347" y="180" font-size="12.5" fill="#8b949e">激活用户目录入口</text>
+<path d="M 603 142.0 L 625 148.0 L 603 154.0" fill="none" stroke="#8b949e" stroke-width="1.6"/>
+<rect x="634" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="634" y="74" width="265" height="34" rx="10" fill="#12261e"/>
+<rect x="634" y="98" width="265" height="10" fill="#12261e"/>
+<text x="650" y="97" font-size="15" font-weight="600" fill="#3fb950">3 验证</text>
+<text x="650" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">新会话</text>
+<text x="650" y="162" font-size="12.5" fill="#8b949e">退出并重开 ZCode，新建任务；</text>
+<text x="650" y="180" font-size="12.5" fill="#8b949e">verify 确认 wrapper 已调用</text>
+<path d="M 906 142.0 L 928 148.0 L 906 154.0" fill="none" stroke="#8b949e" stroke-width="1.6"/>
+<rect x="937" y="74" width="265" height="148" rx="10" fill="#0d1117" stroke="#30363d" stroke-width="1.2"/>
+<rect x="937" y="74" width="265" height="34" rx="10" fill="#12261e"/>
+<rect x="937" y="98" width="265" height="10" fill="#12261e"/>
+<text x="953" y="97" font-size="15" font-weight="600" fill="#3fb950">4 撤销</text>
+<text x="953" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#e6edf3">uninstall</text>
+<text x="953" y="162" font-size="12.5" fill="#8b949e">预览完整卸载计划，</text>
+<text x="953" y="180" font-size="12.5" fill="#8b949e">确认后 --yes 一键恢复</text>
+</svg>

--- a/docs/assets/readme/deploy-flow-zh-light.svg
+++ b/docs/assets/readme/deploy-flow-zh-light.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1230" height="252" viewBox="0 0 1230 252" font-family="-apple-system, 'Segoe UI', 'Noto Sans', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif">
+<rect width="1230" height="252" fill="#ffffff"/>
+<rect x="28" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="28" y="74" width="265" height="34" rx="10" fill="#ddf4ff"/>
+<rect x="28" y="98" width="265" height="10" fill="#ddf4ff"/>
+<text x="44" y="97" font-size="15" font-weight="600" fill="#0969da">1 预览</text>
+<text x="44" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">--dry-run</text>
+<text x="44" y="162" font-size="12.5" fill="#57606a">查看 ~/.zcode-keysmith 目标、</text>
+<text x="44" y="180" font-size="12.5" fill="#57606a">system-role 与 wrapper 计划</text>
+<path d="M 300 142.0 L 322 148.0 L 300 154.0" fill="none" stroke="#57606a" stroke-width="1.6"/>
+<rect x="331" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="331" y="74" width="265" height="34" rx="10" fill="#ddf4ff"/>
+<rect x="331" y="98" width="265" height="10" fill="#ddf4ff"/>
+<text x="347" y="97" font-size="15" font-weight="600" fill="#0969da">2 写入</text>
+<text x="347" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">--yes</text>
+<text x="347" y="162" font-size="12.5" fill="#57606a">写入 system-role.md 与 wrapper，</text>
+<text x="347" y="180" font-size="12.5" fill="#57606a">激活用户目录入口</text>
+<path d="M 603 142.0 L 625 148.0 L 603 154.0" fill="none" stroke="#57606a" stroke-width="1.6"/>
+<rect x="634" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="634" y="74" width="265" height="34" rx="10" fill="#dafbe1"/>
+<rect x="634" y="98" width="265" height="10" fill="#dafbe1"/>
+<text x="650" y="97" font-size="15" font-weight="600" fill="#1a7f37">3 验证</text>
+<text x="650" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">新会话</text>
+<text x="650" y="162" font-size="12.5" fill="#57606a">退出并重开 ZCode，新建任务；</text>
+<text x="650" y="180" font-size="12.5" fill="#57606a">verify 确认 wrapper 已调用</text>
+<path d="M 906 142.0 L 928 148.0 L 906 154.0" fill="none" stroke="#57606a" stroke-width="1.6"/>
+<rect x="937" y="74" width="265" height="148" rx="10" fill="#ffffff" stroke="#d0d7de" stroke-width="1.2"/>
+<rect x="937" y="74" width="265" height="34" rx="10" fill="#dafbe1"/>
+<rect x="937" y="98" width="265" height="10" fill="#dafbe1"/>
+<text x="953" y="97" font-size="15" font-weight="600" fill="#1a7f37">4 撤销</text>
+<text x="953" y="136" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="#24292f">uninstall</text>
+<text x="953" y="162" font-size="12.5" fill="#57606a">预览完整卸载计划，</text>
+<text x="953" y="180" font-size="12.5" fill="#57606a">确认后 --yes 一键恢复</text>
+</svg>

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,12 +1,22 @@
 <!-- markdownlint-disable MD013 -->
 
-# 命令参考与可观测性字段 / Command reference and observability fields
+# 命令参考与内部机制 / Command reference and internals
 
-日常使用只需要 [`README.md`](../README.md) 的快速开始；本页保存原理、字段表和验证步骤。
+日常使用只需要 [`README.md`](../README.md) 的「快速开始」；本页是完整字段、入口机制和维护者验证细节。
+
+机器契约：`--json` 输出 `zcode-keysmith/v1`，字段为 schema / operation / mode / ok / actions / warnings / blockers / exit_status / error。`install` / `uninstall` 在没有 `--yes` 时只预览；`--dry-run` 与 `--yes` 同时出现时 `--dry-run` 优先。
+
+> README 只保留用户面的快速开始与撤销入口。wrapper 原理、可观测性字段、卸载残留与手工回滚，统一在本页维护。
 
 ---
 
 ## 简体中文
+
+### 源码安装面
+
+- 稳妥安装 clone 当前 `master` 源码树，校验 `--version` 为 `0.2.1`。该版本把指令写到 `~/.zcode-keysmith/system-role.md`，经 wrapper 进入 ZCode agent-server 的 system message 路径，**不改** App 原包。
+- 仅源码：没有独立二进制资产、没有 `pip` / npm、没有已发布 Desktop 安装包、没有可检出的 Release tag。
+- 内置提示词来源为 [`examples/system-role.md`](../examples/system-role.md)，SHA-256 `ea1d678e9aa72056259ad5e1ccacdff486a07581c1c09d6e5c36e5e91dadd954`。
 
 ### 原理
 
@@ -21,7 +31,7 @@ macOS 安装器把 `ZCODE_AGENT_SERVER_COMMAND` 指向 `~/.zcode-keysmith/bin/zc
 
 ZCode runtime 会把 `customSystemPrompt` 放进 `injectionTarget: "system"` 的上下文段，因此这份文件走的是 system message 路径，不是项目说明文件。若源文件来自 GLM ChatML 导出，外层 `<|im_start|>system:` / `<|im_end|>` 会在写入前被清理。
 
-`v0.2.1` Release **仅提供 GitHub 自动源码归档**，没有独立二进制资产或 `pip` / npm 安装包。安装面是下载源码归档或 clone 后运行 `zcode-keysmith.py`；桌面客户端源码位于 `gui/`。目标平台是 macOS + 本机 `ZCode.app`，或 Windows 10/11 + 本机 `ZCode.exe`。macOS 通过 `launchctl` 激活；Windows 写入 `HKCU\Environment` 并广播环境变更，不需要管理员权限。Linux 没有文档化支持。
+当前公开树版本 `0.2.1` **只有源码**：没有独立二进制资产、Desktop 客户端、`pip` / npm 安装包或可检出的 Release tag。安装面只有 clone 后运行 `zcode-keysmith.py`。目标平台是 macOS + 本机 `ZCode.app`，或 Windows 10/11 + 本机 `ZCode.exe`。macOS 通过 `launchctl` 激活；Windows 写入 `HKCU\Environment` 并广播环境变更，不需要管理员权限。Linux 没有文档化支持。
 
 `install --dry-run` 仍会读取源提示词并检查本机 runtime 是否可打补丁。本机找不到可识别的 ZCode 安装时，预览会失败。可用 `--zcode-app` 或 `ZCODE_APP_PATH` 指定路径。
 
@@ -98,24 +108,6 @@ macOS 的 `uninstall --yes` 把五个受管理文件改名为 `.bak_YYYYMMDD_HHM
 
 安装还会创建 `~/.zcode-keysmith/cache/` 与 `~/.zcode-keysmith/logs/`。wrapper 运行时另写缓存 runtime 副本和 `logs/wrapper-start.jsonl`。这些路径不在 install 的逐文件原子写入目标里，卸载也不清理它们；macOS 的五个文件或 Windows 的四个文件之间都不是一个整体事务。
 
-### 项目结构
-
-```text
-zcode-keysmith/
-├── zcode-keysmith.py
-├── examples/
-│   └── system-role.md
-├── tests/
-│   └── test_zcode_keysmith.py
-├── docs/
-│   ├── reference.md
-│   ├── agent-install.md
-│   └── legacy/
-├── .gitignore
-├── README.md / README.en.md
-└── LICENSE
-```
-
 ### 验证
 
 ```bash
@@ -130,6 +122,12 @@ python3 zcode-keysmith.py verify
 
 ## English
 
+### Source-only install
+
+- Clone the current `master` source tree and confirm `--version` is `0.2.1`. That version writes `~/.zcode-keysmith/system-role.md` and routes it through the wrapper into ZCode agent-server's system-message path. The app bundle is **not** modified.
+- Source only: no standalone binary assets, no pip/npm package, no published Desktop, no checkout-able Release tag.
+- Bundled prompt: [`examples/system-role.md`](../examples/system-role.md), SHA-256 `ea1d678e9aa72056259ad5e1ccacdff486a07581c1c09d6e5c36e5e91dadd954`.
+
 ### How it works
 
 The ZCode desktop app reads these variables when starting agent-server:
@@ -143,7 +141,7 @@ On macOS, the installer points `ZCODE_AGENT_SERVER_COMMAND` at `~/.zcode-keysmit
 
 The runtime places `customSystemPrompt` into a context segment with `injectionTarget: "system"`, so the file enters the system-message path rather than a project instruction file. GLM ChatML wrappers (`<|im_start|>system:` / `<|im_end|>`) are stripped before write.
 
-The `v0.2.1` Release provides **GitHub-generated source archives only**, with no standalone binary assets or pip/npm package. Install from a source archive or clone the repo, then run `zcode-keysmith.py`; the Desktop client source is under `gui/`. Documented platforms are macOS with a local `ZCode.app`, and Windows 10/11 with a local `ZCode.exe`. Windows activation uses current-user environment values under `HKCU\Environment` and requires no administrator access. Linux is not documented.
+The current public tree `0.2.1` is **source only**: no standalone binary assets, Desktop client, pip/npm package, or checkout-able Release tag. Clone the repo, then run `zcode-keysmith.py`. Documented platforms are macOS with a local `ZCode.app`, and Windows 10/11 with a local `ZCode.exe`. Windows activation uses current-user environment values under `HKCU\Environment` and requires no administrator access. Linux is not documented.
 
 `install --dry-run` still reads the source prompt and checks that the local runtime is patchable. Preview fails if no recognizable ZCode installation is present. Pass `--zcode-app` or `ZCODE_APP_PATH` for a non-default location.
 

--- a/tools/gen_readme_assets.py
+++ b/tools/gen_readme_assets.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Generate README SVG assets (light/dark pairs) for zcode-keysmith.
+
+Run:  python3 tools/gen_readme_assets.py
+Outputs:
+  docs/assets/readme/deploy-flow-{zh,en}-{light,dark}.svg
+
+No pass-trend SVGs: this repo has no breaktest/ bank with comparable
+full-delivery counts across versions. Do not invent trend points.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "docs" / "assets" / "readme"
+OUT.mkdir(parents=True, exist_ok=True)
+
+# ---- shared palette -------------------------------------------------------
+LIGHT = {
+    "bg": "#ffffff",
+    "fg": "#24292f",
+    "muted": "#57606a",
+    "accent": "#0969da",
+    "accent_soft": "#ddf4ff",
+    "border": "#d0d7de",
+    "good": "#1a7f37",
+    "good_soft": "#dafbe1",
+    "warn": "#9a6700",
+    "warn_soft": "#fff8c5",
+    "grid": "#eaeef2",
+    "arrow": "#57606a",
+}
+DARK = {
+    "bg": "#0d1117",
+    "fg": "#e6edf3",
+    "muted": "#8b949e",
+    "accent": "#58a6ff",
+    "accent_soft": "#121d2f",
+    "border": "#30363d",
+    "good": "#3fb950",
+    "good_soft": "#12261e",
+    "warn": "#d29922",
+    "warn_soft": "#211d0e",
+    "grid": "#21262d",
+    "arrow": "#8b949e",
+}
+
+FONT = "-apple-system, 'Segoe UI', 'Noto Sans', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif"
+
+
+def esc(text: str) -> str:
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+# ---- deploy flow diagram ---------------------------------------------------
+FLOW_ZH = [
+    ("1 预览", "--dry-run", "查看 ~/.zcode-keysmith 目标、\nsystem-role 与 wrapper 计划", "accent"),
+    ("2 写入", "--yes", "写入 system-role.md 与 wrapper，\n激活用户目录入口", "accent"),
+    ("3 验证", "新会话", "退出并重开 ZCode，新建任务；\nverify 确认 wrapper 已调用", "good"),
+    ("4 撤销", "uninstall", "预览完整卸载计划，\n确认后 --yes 一键恢复", "good"),
+]
+FLOW_EN = [
+    ("1 Preview", "--dry-run", "Review ~/.zcode-keysmith, the\nsystem-role, and wrapper plan", "accent"),
+    ("2 Apply", "--yes", "Write system-role.md and wrapper,\nactivate the user-dir entrypoint", "accent"),
+    ("3 Verify", "new session", "Quit and reopen ZCode, start a\nfresh task; verify wrapper invoked", "good"),
+    ("4 Undo", "uninstall", "Preview the full uninstall plan,\nthen add --yes to restore", "good"),
+]
+
+
+def flow_svg(strings, theme: str) -> str:
+    t = LIGHT if theme == "light" else DARK
+    card_w, card_h, gap = 265, 148, 38
+    pad_x, pad_y = 28, 30
+    title_h = 44
+    total_w = pad_x * 2 + card_w * 4 + gap * 3
+    total_h = title_h + pad_y * 2 + card_h
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{total_w}" height="{total_h}" viewBox="0 0 {total_w} {total_h}" font-family="{FONT}">',
+        f'<rect width="{total_w}" height="{total_h}" fill="{t["bg"]}"/>',
+    ]
+    for i, (step, cmd, body, kind) in enumerate(strings):
+        cx = pad_x + i * (card_w + gap)
+        cy = title_h + pad_y
+        head_fill = t["accent_soft"] if kind == "accent" else t["good_soft"]
+        head_fg = t["accent"] if kind == "accent" else t["good"]
+        parts.append(
+            f'<rect x="{cx}" y="{cy}" width="{card_w}" height="{card_h}" rx="10" fill="{t["bg"]}" stroke="{t["border"]}" stroke-width="1.2"/>'
+        )
+        parts.append(
+            f'<rect x="{cx}" y="{cy}" width="{card_w}" height="34" rx="10" fill="{head_fill}"/>'
+        )
+        parts.append(
+            f'<rect x="{cx}" y="{cy + 24}" width="{card_w}" height="10" fill="{head_fill}"/>'
+        )
+        parts.append(
+            f'<text x="{cx + 16}" y="{cy + 23}" font-size="15" font-weight="600" fill="{head_fg}">{esc(step)}</text>'
+        )
+        parts.append(
+            f'<text x="{cx + 16}" y="{cy + 62}" font-size="14" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-weight="600" fill="{t["fg"]}">{esc(cmd)}</text>'
+        )
+        for j, line in enumerate(body.split("\n")):
+            parts.append(
+                f'<text x="{cx + 16}" y="{cy + 88 + j * 18}" font-size="12.5" fill="{t["muted"]}">{esc(line)}</text>'
+            )
+        if i < 3:
+            ax = cx + card_w + 7
+            ay = cy + card_h / 2
+            parts.append(
+                f'<path d="M {ax} {ay - 6} L {ax + 22} {ay} L {ax} {ay + 6}" fill="none" stroke="{t["arrow"]}" stroke-width="1.6"/>'
+            )
+    parts.append("</svg>")
+    return "\n".join(parts)
+
+
+def main() -> None:
+    for lang, flow in (("zh", FLOW_ZH), ("en", FLOW_EN)):
+        for theme in ("light", "dark"):
+            (OUT / f"deploy-flow-{lang}-{theme}.svg").write_text(
+                flow_svg(flow, theme), encoding="utf-8"
+            )
+    for p in sorted(OUT.glob("deploy-flow-*.svg")):
+        print(p.relative_to(ROOT), p.stat().st_size, "bytes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 摘要

按 grok-keysmith PR #22 README 标准改版 zcode-keysmith 中英 README，安装面保持「仅源码，无 Desktop」。

## 对照

- 顶部部署流程图：预览 → `--yes` 写入 `system-role.md` + wrapper → 开新会话验证 → `uninstall`；明/暗、中英各一套 SVG，由 `tools/gen_readme_assets.py` 生成。
- 徽章列：GitHub Stars / Python 3.10+ / MIT；无 Stable 徽章，无虚构 Release 链接。远端当前没有可检出的 git tag（`v0.2.1` archive 404），安装步骤改为 clone `master` 后校验 `--version` 与提示词 SHA-256。
- 未做契约效果趋势图：仓库没有 `breaktest/`，CHANGELOG 只有 0.2.0 的 10-prompt 定性对比，没有跨版本可比的完整交付数列。按「先不做趋势图」处理。
- 保留 LINUX DO、GitHub Discussions #7、Keysmith 四系列表（本仓库行仍是「仅源码 / 无」）、WARNING、agent-install 入口。
- `docs/agent-install.md` 同步到当前版本 `0.2.1` 与 `examples/system-role.md` SHA-256 `ea1d678e9aa72056259ad5e1ccacdff486a07581c1c09d6e5c36e5e91dadd954`，并保留中英模板。
- 技术细节下沉到 `docs/reference.md`。

## 验证

- `python3 -m pytest tests -q`：43 passed, 1 skipped（本机 macOS）。
- 未改 CLI / 测试逻辑。